### PR TITLE
highlight 9.11.0 -> 9.18.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://gluons.github.io/vue-highlight.js/",
   "peerDependencies": {
-    "highlight.js": "^9.11.0",
+    "highlight.js": "^9.18.5",
     "vue": "2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4201,9 +4201,9 @@ hex-color-regex@^1.1.0:
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
 highlight.js@^9.15.8:
-  version "9.15.10"
-  resolved "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz#7b18ed75c90348c045eef9ed08ca1319a2219ad2"
-  integrity sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==
+  version "9.18.5"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
+  integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Alternate to https://github.com/gluons/vue-highlight.js/pull/68 , which includes a [fix](https://github.com/highlightjs/highlight.js/pull/2636) [for a prototype pollution CVE](https://nvd.nist.gov/vuln/detail/CVE-2020-26237):  

* #68 is a major version bump to 10.x.x, and there are [breaking changes](https://github.com/highlightjs/highlight.js/blob/master/VERSION_10_UPGRADE.md)
* #68 's tests are breaking: https://travis-ci.org/github/gluons/vue-highlight.js/jobs/744984772
* the 9.x.x stream of highlight.js is [not supported anymore](https://github.com/highlightjs/highlight.js/blob/master/SECURITY.md), but they did [backport the fix to 9.18.x](https://github.com/highlightjs/highlight.js/commit/107d97b1f048cdf6da215c5ef1f0ece536af3656)